### PR TITLE
Use more compatible alignment for embed

### DIFF
--- a/src/pages/embed.module.css
+++ b/src/pages/embed.module.css
@@ -10,7 +10,7 @@
   margin: 0;
   display: flex;
   overflow: hidden;
-  align-items: last baseline;
+  align-items: baseline;
 }
 
 .embedLayout > * {


### PR DESCRIPTION
It isn't clear that Chrome supports `text-align: last baseline`. Since the content isn't aligned correctly on Chrome, I suspect it doesn't. `text-align: baseline` should work equivalently since we only have one line of text.