### PR TITLE
Use flex-end for bottom alignment instead of `last baseline`

### DIFF
--- a/src/pages/embed.module.css
+++ b/src/pages/embed.module.css
@@ -10,7 +10,7 @@
   margin: 0;
   display: flex;
   overflow: hidden;
-  align-items: last baseline;
+  align-items: flex-end;
 }
 
 .embedLayout > * {


### PR DESCRIPTION
@hcs64 This works for me locally in Chrome and Firefox. Can you check that it works for you too? If so, feel free to merge the PR (you should have permission once you accept the invite I sent you).

Fixes #1.