### PR TITLE
Change mhowell's site's title

### DIFF
--- a/data/members.yaml
+++ b/data/members.yaml
@@ -19,9 +19,9 @@
   url: https://www.futch.dev
 
 - id: mhowell
-  title: XBill
+  title: molly howell's site
   description: mhowell's personal mistake
-  url: https://mistake.computer
+  url: http://mistake.computer
 
 - id: dana
   title: "codename: dana"

--- a/data/members.yaml
+++ b/data/members.yaml
@@ -21,7 +21,7 @@
 - id: mhowell
   title: molly howell's site
   description: mhowell's personal mistake
-  url: http://mistake.computer
+  url: https://mistake.computer
 
 - id: dana
   title: "codename: dana"


### PR DESCRIPTION
There's more content on mistake.computer now than just xbill, so the title needs to be changed. The description is still perfectly correct.

Also, https://mistake.computer doesn't work right now because I can't figure out know how to DNS (the HTTP version redirects to HTTPS). I'll update this again if I can ever fix it.